### PR TITLE
add github action Continuous Integration

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,6 @@
+APP_ENV=testing
+APP_KEY=
+
+CACHE_DRIVER=array
+SESSION_DRIVER=array
+QUEUE_DRIVER=sync

--- a/.github/workflows/basic-test-suite-workflow.yml
+++ b/.github/workflows/basic-test-suite-workflow.yml
@@ -1,0 +1,33 @@
+name: Basic Test Suite
+ 
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      matrix: 
+        platform: [ubuntu-18.04]
+
+    runs-on: ${{ matrix.platform }}
+    
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: Copy ENV Laravel Configuration for CI
+      run: php -r "file_exists('.env') || copy('.env.ci', '.env');"
+    
+    - name: Install Dependencies (PHP vendors)
+      run: composer install -q --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+    
+    - name: Generate key
+      run: php artisan key:generate
+   
+# enable database step when needed  
+#     - name: Create DB and schemas
+#       run: |
+#         mkdir -p database
+#         touch database/database.sqlite
+#         php artisan migrate
+    
+    - name: Execute tests (Unit and Feature tests) via PHPUnit
+      run: vendor/bin/phpunit

--- a/.github/workflows/extended-test-suite-workflow.yml
+++ b/.github/workflows/extended-test-suite-workflow.yml
@@ -1,0 +1,67 @@
+# name of the action
+name: Extended Test Suite
+
+# run this action on
+on:
+  push:
+    # on push events to master, run extended suite
+    branches: 
+      - master  
+    # when commits are tagged, they are important, run extended suite
+    tags:
+    - '*'
+  
+  # when release published, run extended suite
+  release:
+    types: [published]
+  
+# jobs execute in parallel, we can however specify dependence, if any
+jobs:
+  
+  # A job to setup php and run all the tests
+  run-tests:
+    
+    # parallel test for matrix builds
+    strategy:
+      max-parallel: 10
+      matrix: 
+        platform: [ubuntu-latest, ubuntu-18.04, ubuntu-16.04]
+        php-versions: ['7.2', '7.3']
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.platform }}
+    
+    # platform for this build
+    runs-on: ${{ matrix.platform }}
+    
+    # steps to be done in this job
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v1
+    
+    - name: Install PHP
+      uses: shivammathur/setup-php@master
+      with:
+        php-version: ${{ matrix.php-versions }}
+    
+    - name: Verify PHP and composer Installation
+      run: |
+        php -v
+        composer -V  
+    
+    - name: Copy ENV Laravel Configuration for CI
+      run: php -r "file_exists('.env') || copy('.env.ci', '.env');"
+    
+    - name: Install Dependencies (PHP vendors)
+      run: composer install -q --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+    
+    - name: Generate key
+      run: php artisan key:generate
+   
+# enable database step when needed  
+#     - name: Create DB and schemas
+#       run: |
+#         mkdir -p database
+#         touch database/database.sqlite
+#         php artisan migrate
+    
+    - name: Execute tests (Unit and Feature tests) via PHPUnit
+      run: vendor/bin/phpunit


### PR DESCRIPTION
## Motivation

Travis is third party. Why not use GitHub actions now that we have them?
GitHub actions are much more flexible and provides an in-house solution for our needs.

## Work done

Created workflows for two types of test suites. Comments have been added to workflows. They are easy to edit to include new OS's and new php versions.

- basic test suite 
  - This runs on every push and pull request in every branch
  - This runs ubuntu 18 and php^7.2 

- extended test suite 
  - this runs for every master branch push
  - This runs for every tag and release 
  - This is a matrix build 
    - runs ubuntu latest and php=7.2
    - runs ubuntu latest and php=7.3
    - runs ubuntu 18.04 and php=7.2
    - runs ubuntu 18.04 and php=7.3
    - runs ubuntu 16.04 and php=7.2
    - runs ubuntu 16.04 and php=7.3
  - This brings into light any bugs that might creep in when the system is deployed to production.

This renders travis unnecessary in this project. You may keep/remove travis based on your preferences. I've not modified any files related to travis as of now.